### PR TITLE
fix(`--ignore die`): to list "cores" underneath "machine"

### DIFF
--- a/hwloc_xml_parser/topology.py
+++ b/hwloc_xml_parser/topology.py
@@ -109,7 +109,7 @@ class SystemTopology:
         if load: self._load(caches = caches, io = io, bridges = bridges)
 
     @typeguard.typechecked
-    def _load(self, caches : bool = False, io : bool = False, bridges : bool = False) -> None:
+    def _load(self, caches : bool = False, io : bool = False, bridges : bool = False, die : bool = False) -> None:
         """
         Initialize the system topology from `lstopo-no-graphics`.
         """
@@ -118,6 +118,9 @@ class SystemTopology:
         if not caches : cmd.append('--no-caches')
         if not io     : cmd.append('--no-io')
         if not bridges: cmd.append('--no-bridges')
+        if not die    :
+            cmd.append('--ignore')
+            cmd.append('die')
 
         with tempfile.NamedTemporaryFile(mode = 'w+', suffix = '.xml') as filename:
 
@@ -163,12 +166,12 @@ class SystemTopology:
         # Set the logical indices for the packages, cores, and PUs.
         for objects in [self.packages, list(self.recurse_cores()), list(self.recurse_pus())]:
             logical_indices = Object.get_logical_from_physical(
-            type = objects[0].type,
-            hierarchical_indices = [obj.hierarchical_index for obj in objects]
-        )
+                type = objects[0].type,
+                hierarchical_indices = [obj.hierarchical_index for obj in objects]
+            )
 
-        for obj, logical_index in zip(objects, logical_indices):
-            obj.logical_index = logical_index
+            for obj, logical_index in zip(objects, logical_indices):
+                obj.logical_index = logical_index
 
     @typeguard.typechecked
     def __str__(self) -> str:

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -99,6 +99,10 @@ class TestSystemTopology:
             assert package.cores[1].pus[1].os_index      == 5
             assert package.cores[1].pus[1].logical_index == 3
 
+            # The third core of the package has OS index 2 and logical index 2.
+            assert package.cores[2].os_index      == 2
+            assert package.cores[2].logical_index == 2
+
             # All cores of the package have 2 PUs.
             assert package.all_equal_num_pus_per_core()
 
@@ -244,6 +248,10 @@ class TestSystemTopology:
             # The first core of the first package has 2 PUs.
             assert len(first_package.cores[0].pus) == 2
             assert first_package.cores[0].get_num_pus() == 2
+
+            # The nine-th core of the first package has OS index 10 and logical index 8.
+            assert first_package.cores[8].os_index      == 10
+            assert first_package.cores[8].logical_index == 8
 
             # All cores of the first package have 2 PUs.
             assert first_package.all_equal_num_pus_per_core()


### PR DESCRIPTION
On one of our machines, `lstopo` has started to report a "Die" level. This PR adds an option to ignore this level by default because our parser currently can't handle it.