### PR TITLE
mypyc and cibuildwheel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,14 +41,17 @@ jobs:
         runs-on: ubuntu-latest
         container:
             image: ${{ needs.set-vars.outputs.CI_IMAGE }}:2.9.0
+        services:
+            docker:
+                image: docker:dind
         steps:
             - uses: actions/checkout@v5
-            - run: python -m pip install -U build
-            - run: python -m build
+            - run: python -m pip install -U cibuildwheel
+            - run: python -m cibuildwheel --output-dir wheelhouse
             - uses: actions/upload-artifact@v4
               with:
                   name: package
-                  path: dist/
+                  path: wheelhouse/
                   retention-days: 1
 
     install-as-package-and-test:
@@ -67,10 +70,10 @@ jobs:
             - uses: actions/download-artifact@v4
               with:
                   name: package
-                  path: dist/
+                  path: wheelhouse/
 
             - run: |
-                  python -m pip install dist/*.whl
+                  python -m pip install --no-index --find-links=wheelhouse/ hwloc_xml_parser
                   python -m pip show hwloc_xml_parser
 
             - name: Test package.

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.10 AS requirements
+FROM python:3.11 AS requirements
 
 RUN python3 -m pip install mypy[mypyc] pytest system-helpers>=0.0.3 typeguard
 
-RUN apt-helpers install-packages --update --clean --packages git
+RUN apt-helpers install-packages --update --clean --packages git docker.io
 
 FROM requirements AS compile-hwloc
 

--- a/hwloc_xml_parser/topology.py
+++ b/hwloc_xml_parser/topology.py
@@ -91,6 +91,8 @@ class SystemTopology:
     References:
         * https://hwloc.readthedocs.io/en/stable/tools.html#cli_lstopo
     """
+    LSTOPO_NO_GRAPHICS : typing.Final[str] = 'lstopo-no-graphics'
+
     def __init__(self, load : bool = True, caches : bool = False, io : bool = False, bridges : bool = False) -> None:
         """
         Initialize with optional load of the system topology from `lstopo-no-graphics`.
@@ -101,7 +103,7 @@ class SystemTopology:
         """
         Initialize the system topology from `lstopo-no-graphics`.
         """
-        cmd = ['lstopo-no-graphics', '--no-collapse']
+        cmd = [self.LSTOPO_NO_GRAPHICS, '--no-collapse']
 
         if not caches : cmd.append('--no-caches')
         if not io     : cmd.append('--no-io')
@@ -201,16 +203,16 @@ class SystemTopology:
         """
         Returns the number of cores.
         """
-        return sum([package.get_num_cores() for package in self.packages])
+        return sum(package.get_num_cores() for package in self.packages)
 
     def get_num_pus(self) -> int:
         """
         Returns the number of processing units.
         """
-        return sum([package.get_num_pus() for package in self.packages])
+        return sum(package.get_num_pus() for package in self.packages)
 
     def all_equal_num_pus_per_core(self) -> bool:
         """
         Returns `True` if all cores have the same number of processing units.
         """
-        return all([package.all_equal_num_pus_per_core() for package in self.packages])
+        return all(package.all_equal_num_pus_per_core() for package in self.packages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "mypy[mypyc]"]
+requires = ["setuptools>=78", "mypy[mypyc]"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -30,3 +30,13 @@ authors = [
 
 [project.urls]
 Homepage = "https://github.com/uliegecsm/hwloc-xml-parser"
+
+[tool.cibuildwheel]
+build = ["cp31[0-9]-manylinux*"]
+archs = ["x86_64"]
+
+test-requires = ["pytest"]
+test-sources = ["tests"]
+test-command = "pytest {project}/tests"
+
+build-verbosity = 1

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,7 +1,10 @@
 import itertools
+import shutil
 import subprocess
 import unittest
 from unittest.mock import call
+
+import pytest
 
 from hwloc_xml_parser.topology import SystemTopology
 
@@ -329,6 +332,7 @@ class TestSystemTopology:
             # All cores of the machine have the same number of PUs.
             assert st.all_equal_num_pus_per_core()
 
+    @pytest.mark.skipif(shutil.which(cmd = SystemTopology.LSTOPO_NO_GRAPHICS) is None, reason = f'{SystemTopology.LSTOPO_NO_GRAPHICS} not found')
     def test_parse(self):
         """
         Run the tool and check that it parses to something meaningful, whatever the machine.


### PR DESCRIPTION
`cibuildwheel` requires `Python >= 3.11`. So I bumped our images to it.

It relies on `Docker` containers for covering multiple `Python` versions in a single build. So our image also gets `docker.io`, and the build step needs the `docker:dind` service.

The configuration for `cibuildwheel` is contained in our `pyproject.toml`. We restrict to a few supported versions for now.

~~The reason for running the build step in our image is that our tests need `lstopo-no-graphics`.~~ Tests are run in the container that `cibuildwheel` uses for building the wheel.